### PR TITLE
Fixing 'getzlibsock.c:145:42: warning: format '%d' expects argument ...

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: seqinr
 Title: Biological Sequences Retrieval and Analysis
-Version: 4.2-33
+Version: 4.2-34
 Depends: R (>= 2.10.0)
 Imports: ade4,segmented
 Authors@R: c(person("Delphine", "Charif", role = "aut"),

--- a/src/getzlibsock.c
+++ b/src/getzlibsock.c
@@ -142,7 +142,7 @@ SEXP getzlibsock(SEXP sock, SEXP nmax, SEXP debug)
 	return ans ;
 	}
   if (debugon)
-  	Rprintf("Socket answer is ok %s(%d)\n",res, strlen(res));		 
+  	Rprintf("Socket answer is ok %s\n",res);		 
   nn = (n < 0) ? 1000 : n; /* initially allocate space for 1000 lines */
   nnn = (n < 0) ? INT_MAX : n;
   PROTECT(ans = allocVector(STRSXP, nn));


### PR DESCRIPTION
Fix the following WARNING:
 
checking whether package ‘seqinr’ can be installed ... [21s/32s] WARNING
Found the following significant warnings:
  getzlibsock.c:145:42: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
