### PR TITLE
Fixing bug on small alignment https://github.com/lbbe-software/seqinr/issues/10

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: seqinr
 Title: Biological Sequences Retrieval and Analysis
-Version: 4.2-39
+Version: 4.2-40
 Depends: R (>= 2.10.0)
 Imports: ade4,segmented
 Authors@R: c(person("Delphine", "Charif", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: seqinr
 Title: Biological Sequences Retrieval and Analysis
-Version: 4.2-40
+Version: 4.2-41
 Depends: R (>= 2.10.0)
 Imports: ade4,segmented
 Authors@R: c(person("Delphine", "Charif", role = "aut"),

--- a/R/read.alignment.R
+++ b/R/read.alignment.R
@@ -54,7 +54,6 @@ read.alignment <- function(file, format, forceToLower = TRUE,
       white <- characters[-length(characters)] == " "
       black <- characters[-1] != " "
       istart <- which(white & black)[1]
-
       # Get sequence names
       nam <- character()
       nseq <- 1
@@ -74,7 +73,12 @@ read.alignment <- function(file, format, forceToLower = TRUE,
           nseq <- nseq - 1
           break # alredy seen
         }
-        if (seqname == 'NA')  {break}
+        # this happens with short alignments because seqname is never found
+        # in mam
+        if (seqname == 'NA')  {
+          nseq <- nseq - 1
+          break
+        }
         nam[nseq] <- seqname
         nseq <- nseq + 1
       }
@@ -98,14 +102,11 @@ read.alignment <- function(file, format, forceToLower = TRUE,
       # Concatenation of sequence lines in a single string
       seq <- vector(mode = "list")
       for(iseq in seq_len(nseq)){
-        if (iseq <= length(filecontent)) {
-          ii <- seq(iseq, length(filecontent), by = nseq)
-          seq[[iseq]] <- paste0(filecontent[ii], collapse = "")
-          if(forceToLower) seq[[iseq]] <- tolower(seq[[iseq]])
-        }
+        ii <- seq(iseq, length(filecontent), by = nseq)
+        seq[[iseq]] <- paste0(filecontent[ii], collapse = "")
+        if(forceToLower) seq[[iseq]] <- tolower(seq[[iseq]])
       }
-
-      return(as.alignment(nb = length(seq), nam = nam, seq = seq, com = NA))
+      return(as.alignment(nb = nseq, nam = nam, seq = seq, com = NA))
     }
 
 

--- a/R/read.alignment.R
+++ b/R/read.alignment.R
@@ -74,6 +74,7 @@ read.alignment <- function(file, format, forceToLower = TRUE,
           nseq <- nseq - 1
           break # alredy seen
         }
+        if (seqname == 'NA')  {break}
         nam[nseq] <- seqname
         nseq <- nseq + 1
       }
@@ -97,12 +98,14 @@ read.alignment <- function(file, format, forceToLower = TRUE,
       # Concatenation of sequence lines in a single string
       seq <- vector(mode = "list")
       for(iseq in seq_len(nseq)){
-        ii <- seq(iseq, length(filecontent), by = nseq)
-        seq[[iseq]] <- paste0(filecontent[ii], collapse = "")
-        if(forceToLower) seq[[iseq]] <- tolower(seq[[iseq]])
+        if (iseq <= length(filecontent)) {
+          ii <- seq(iseq, length(filecontent), by = nseq)
+          seq[[iseq]] <- paste0(filecontent[ii], collapse = "")
+          if(forceToLower) seq[[iseq]] <- tolower(seq[[iseq]])
+        }
       }
-      #
-      return(as.alignment(nb = nseq, nam = nam, seq = seq, com = NA))
+
+      return(as.alignment(nb = length(seq), nam = nam, seq = seq, com = NA))
     }
 
 


### PR DESCRIPTION
The only difference between 4.2-39 is at ligne 77

       if (seqname == 'NA')  {
          nseq <- nseq - 1
          break
        }
